### PR TITLE
Gradioインターフェースの削除とデフォルト値処理の改善

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ GCP_SERVICE_ACCOUNT_KEY_PATH=
 # Required: List of GCP project IDs
 PROJECT_IDS=
 
-# Required: List of dataset filters (e.g., pj1.*,pj2.dataset1)
+# Optional: List of dataset filters (e.g., pj1.*,pj2.dataset1)
 DATASET_FILTERS=
 
 # --- Cache Settings ---

--- a/README-ja.md
+++ b/README-ja.md
@@ -114,12 +114,6 @@ python -m bq_meta_api.adapters.mcp_server
 python -m bq_meta_api.adapters.web
 ```
 
-### Gradio Webインターフェースの起動
-
-```bash
-python -m bq_meta_api.adapters.bq_agent_gradio
-```
-
 ### 開発用コマンド
 
 #### コードフォーマットとリンティング

--- a/README.md
+++ b/README.md
@@ -114,12 +114,6 @@ python -m bq_meta_api.adapters.mcp_server
 python -m bq_meta_api.adapters.web
 ```
 
-### Starting the Gradio Web Interface
-
-```bash
-python -m bq_meta_api.adapters.bq_agent_gradio
-```
-
 ### Development Commands
 
 #### Code Formatting and Linting

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -31,6 +31,19 @@ def extract_env_variables_from_settings() -> List[Tuple[str, Any, str]]:
             # Handle PydanticUndefined appropriately
             if str(field_info.default) != "PydanticUndefined":
                 default_value = field_info.default
+        elif (
+            hasattr(field_info, "default_factory")
+            and field_info.default_factory is not None
+        ):
+            # Handle default_factory by calling it to get the actual default
+            try:
+                default_value = field_info.default_factory()
+                # Convert empty containers to None for cleaner output
+                if default_value == [] or default_value == {} or default_value == set():
+                    default_value = None  # Will be shown as empty in .env.example
+            except Exception:
+                # If default_factory fails, treat as having a default but don't show the value
+                default_value = None
 
         # Get field type information
         field_type = (
@@ -59,9 +72,15 @@ def generate_comment_for_field(
     # Check if field is Optional[T] type
     import typing
 
-    is_optional = (
+    # Check if field has default value or default_factory
+    has_default = (
         default_value is not None and str(default_value) != "PydanticUndefined"
     ) or (
+        hasattr(field_info, "default_factory")
+        and field_info.default_factory is not None
+    )
+
+    is_optional = has_default or (
         hasattr(field_type, "__origin__")
         and field_type.__origin__ is typing.Union
         and type(None) in field_type.__args__

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -39,7 +39,7 @@ def extract_env_variables_from_settings() -> List[Tuple[str, Any, str]]:
             try:
                 default_value = field_info.default_factory()
                 # Convert empty containers to None for cleaner output
-                if default_value == [] or default_value == {} or default_value == set():
+                if default_value in ([], {}, set()):
                     default_value = None  # Will be shown as empty in .env.example
             except Exception:
                 # If default_factory fails, treat as having a default but don't show the value


### PR DESCRIPTION
fix: Gradioインターフェースの削除とデフォルト値処理の改善

READMEからGradio Webインターフェースの起動セクションを削除し、
環境変数生成スクリプトでdefault_factoryを持つフィールドの
デフォルト値処理を改善。DATASET_FILTERSをオプションに変更。

- README.md/README-ja.mdからGradio関連のドキュメントを削除
- default_factoryによるデフォルト値の適切な処理を追加
- 空のコンテナ（list/dict/set）をNoneに正規化
- DATASET_FILTERSの説明をRequiredからOptionalに修正