### PR TITLE
feat(mcp): クエリ実行プロジェクト設定とデータセットフィルタ最適化を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `pytest` - Run all tests
 - `pytest tests/test_logic.py` - Run specific test file
 - `pytest -k test_function_name` - Run specific test
+- `pytest --cov=bq_mcp` - Run tests with coverage report
+- `pytest -v` - Run tests with verbose output
 
 ### Code Quality
 - `ruff check` - Run linting checks
 - `ruff format` - Format code
 - `lizard` - Run cyclomatic complexity analysis
+- `mypy bq_mcp/` - Run type checking
 
 ### Package Management
 - Uses `uv` for dependency management
@@ -63,11 +66,12 @@ This is a BigQuery metadata API server that provides access to BigQuery dataset,
 **Configuration**: Uses environment variables for GCP authentication and project configuration. Check `repositories/config.py` for available settings.
 
 ### MCP Server Usage
-The MCP server (`mcp_server.py`) is the primary interface, providing four main tools for BigQuery metadata access and query execution:
+The MCP server (`mcp_server.py`) is the primary interface, providing five main tools for BigQuery metadata access and query execution:
 1. `get_datasets` - Lists all available datasets across configured projects
 2. `get_tables` - Lists tables in a specific dataset (requires dataset_id, optional project_id)
 3. `search_metadata` - Searches across datasets, tables, and columns using keywords
-4. `execute_query` - Executes BigQuery SQL with automatic safety checks and LIMIT clause management
+4. `check_query_scan_amount` - Dry-run to check query cost before execution
+5. `execute_query` - Executes BigQuery SQL with automatic safety checks and LIMIT clause management
 
 **Query Execution Features:**
 - Automatic LIMIT clause addition/modification (default: 10 rows)
@@ -94,3 +98,15 @@ Run the MCP server with: `python -m bq_mcp.adapters.mcp_server`
 ### Debugging MCP Issues
 - Check log files in `logs/` directory for debugging information
 - Test with web API (`bq_mcp.adapters.web`) as alternative to stdio MCP for development
+
+### Environment Setup
+Required environment variable:
+- `PROJECT_IDS` - Comma-separated list of GCP project IDs (e.g., "project1,project2")
+
+The application uses Google Cloud Application Default Credentials (ADC) by default. You can also specify:
+- `GCP_SERVICE_ACCOUNT_KEY_PATH` - Path to service account JSON key file
+
+### Running the Application
+- MCP Server: `python -m bq_mcp.adapters.mcp_server`
+- Web API: `python -m bq_mcp.adapters.web` (runs on http://localhost:8080)
+- Gradio UI: `python -m bq_mcp.adapters.bq_agent_gradio`

--- a/README-ja.md
+++ b/README-ja.md
@@ -67,7 +67,9 @@ cp .env.example .env
                 "mcp_server"
             ],
             "env": {
-                "PYTHONPATH": "<your install directory>"
+                "PYTHONPATH": "<your install directory>",
+                "PROJECT_IDS": "<your project id>",
+                "QUERY_EXECUTION_PROJECT_ID": "<your project id>"
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Required environment variables:
                 "mcp_server"
             ],
             "env": {
-                "PYTHONPATH": "<your install directory>"
+                "PYTHONPATH": "<your install directory>",
+                "PROJECT_IDS": "<your project id>",
+                "QUERY_EXECUTION_PROJECT_ID": "<your project id>"
             }
         }
     }

--- a/bq_mcp/core/entities.py
+++ b/bq_mcp/core/entities.py
@@ -179,6 +179,10 @@ class Settings(BaseModel):
     api_port: int = Field(8000, description="API server port number")
 
     # Query execution settings
+    query_execution_project_id: Optional[str] = Field(
+        None,
+        description="Project ID to use for query execution (defaults to first project in project_ids if not set)",
+    )
     max_scan_bytes: int = Field(
         1024 * 1024 * 1024,  # 1GB
         description="Maximum scan bytes for queries",

--- a/bq_mcp/repositories/bigquery_client.py
+++ b/bq_mcp/repositories/bigquery_client.py
@@ -14,6 +14,7 @@ from bq_mcp.core.entities import (
     TableSchema,
 )
 from bq_mcp.repositories import config, log
+from bq_mcp.repositories.config import should_include_dataset
 
 
 def get_bigquery_client() -> Optional[Dataset]:
@@ -188,8 +189,6 @@ async def fetch_datasets(client: Dataset, project_id: str) -> List[DatasetMetada
 
         # Check dataset filter before proceeding with expensive operations
         if settings.dataset_filters:
-            from bq_mcp.repositories.config import should_include_dataset
-
             if not should_include_dataset(
                 actual_project_id, actual_dataset_id, settings.dataset_filters
             ):

--- a/bq_mcp/repositories/config.py
+++ b/bq_mcp/repositories/config.py
@@ -76,6 +76,7 @@ def init_setting() -> Settings:
     api_port = _load_env_variable("API_PORT", 8000, int)
 
     # Query execution settings
+    query_execution_project_id = _load_env_variable("QUERY_EXECUTION_PROJECT_ID")
     max_scan_bytes = _load_env_variable(
         "MAX_SCAN_BYTES", 1024 * 1024 * 1024, int
     )  # 1GB
@@ -92,6 +93,7 @@ def init_setting() -> Settings:
         cache_file_base_dir=cache_file_base_dir,
         api_host=api_host,
         api_port=api_port,
+        query_execution_project_id=query_execution_project_id,
         max_scan_bytes=max_scan_bytes,
         default_query_limit=default_query_limit,
         query_timeout_seconds=query_timeout_seconds,

--- a/bq_mcp/repositories/query_executor.py
+++ b/bq_mcp/repositories/query_executor.py
@@ -25,15 +25,20 @@ class QueryExecutor:
     def _get_client(self, project_id: Optional[str] = None) -> bigquery.Client:
         """Get BigQuery client"""
         if self.client is None:
+            # Use query execution project ID if set, otherwise fall back to provided project_id or first project
+            effective_project_id = (
+                self.settings.query_execution_project_id
+                or project_id
+                or self.settings.project_ids[0]
+            )
+
             if self.settings.gcp_service_account_key_path:
                 self.client = bigquery.Client.from_service_account_json(
                     self.settings.gcp_service_account_key_path,
-                    project=project_id or self.settings.project_ids[0],
+                    project=effective_project_id,
                 )
             else:
-                self.client = bigquery.Client(
-                    project=project_id or self.settings.project_ids[0]
-                )
+                self.client = bigquery.Client(project=effective_project_id)
         assert self.client is not None
         return self.client
 

--- a/bq_mcp/repositories/query_executor.py
+++ b/bq_mcp/repositories/query_executor.py
@@ -25,7 +25,7 @@ class QueryExecutor:
     def _get_client(self, project_id: Optional[str] = None) -> bigquery.Client:
         """Get BigQuery client"""
         if self.client is None:
-            # Use query execution project ID if set, otherwise fall back to provided project_id or first project
+            # Priority order: query_execution_project_id > provided project_id > first project in settings
             effective_project_id = (
                 self.settings.query_execution_project_id
                 or project_id

--- a/tests/test_bigquery_client.py
+++ b/tests/test_bigquery_client.py
@@ -14,7 +14,10 @@ class TestDatasetFilterOptimization:
 
     def test_should_include_dataset_basic_scenarios(self):
         """Test basic scenarios for dataset filtering"""
-        # Test cases that we ran manually
+        # Test cases validating basic dataset filtering scenarios, including:
+        # - Matching and non-matching filters
+        # - Wildcard patterns
+        # - Cases with no filters
         test_cases = [
             ("project1", "dataset1", ["project1.*"], True),
             ("project1", "dataset1", ["project2.*"], False),
@@ -31,7 +34,7 @@ class TestDatasetFilterOptimization:
 
     def test_should_include_dataset_wildcard_patterns(self):
         """Test wildcard pattern matching"""
-        # Patterns from actual configuration
+        # Test patterns representing common real-world dataset filter configurations
         filters = [
             "prj-ai-chatbot.*",
             "pj-cloud-gorillatest.*",

--- a/tests/test_bigquery_client.py
+++ b/tests/test_bigquery_client.py
@@ -1,0 +1,276 @@
+"""Test BigQuery client functionality, especially dataset filter optimization"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bq_mcp.core.entities import Settings
+from bq_mcp.repositories import bigquery_client
+from bq_mcp.repositories.config import should_include_dataset
+
+
+class TestDatasetFilterOptimization:
+    """Test dataset filtering optimization in bigquery_client"""
+
+    def test_should_include_dataset_basic_scenarios(self):
+        """Test basic scenarios for dataset filtering"""
+        # Test cases that we ran manually
+        test_cases = [
+            ("project1", "dataset1", ["project1.*"], True),
+            ("project1", "dataset1", ["project2.*"], False),
+            ("project1", "specific", ["project1.specific"], True),
+            ("project1", "other", ["project1.specific"], False),
+            ("project1", "dataset1", [], True),  # No filters
+        ]
+
+        for project, dataset, filters, expected in test_cases:
+            result = should_include_dataset(project, dataset, filters)
+            assert result == expected, (
+                f"{project}.{dataset} with filters {filters} should be {expected}"
+            )
+
+    def test_should_include_dataset_wildcard_patterns(self):
+        """Test wildcard pattern matching"""
+        # Patterns from actual configuration
+        filters = [
+            "prj-ai-chatbot.*",
+            "pj-cloud-gorillatest.*",
+            "bigquery-public-data.google_cloud_release_notes",
+            "bigquery-public-data.wikipedia",
+            "bigquery-public-data.samples",
+        ]
+
+        # Should include - wildcard matches
+        assert should_include_dataset("prj-ai-chatbot", "any_dataset", filters)
+        assert should_include_dataset("pj-cloud-gorillatest", "test_data", filters)
+
+        # Should include - exact matches
+        assert should_include_dataset("bigquery-public-data", "samples", filters)
+        assert should_include_dataset("bigquery-public-data", "wikipedia", filters)
+
+        # Should exclude
+        assert not should_include_dataset("other-project", "dataset", filters)
+        assert not should_include_dataset(
+            "bigquery-public-data", "other_dataset", filters
+        )
+
+    @patch("bq_mcp.repositories.config.get_settings")
+    @pytest.mark.asyncio
+    async def test_fetch_datasets_filter_optimization(self, mock_get_settings):
+        """Test that fetch_datasets skips filtered datasets efficiently"""
+        # Mock settings with filters
+        mock_settings = MagicMock(spec=Settings)
+        mock_settings.dataset_filters = ["project1.*", "project2.specific"]
+        mock_get_settings.return_value = mock_settings
+
+        # Mock client
+        mock_client = MagicMock()
+        mock_client.session = MagicMock()
+        mock_client.session.session = MagicMock()
+        mock_client.token = MagicMock()
+
+        # Mock dataset list response
+        datasets_list = [
+            {
+                "datasetReference": {"projectId": "project1", "datasetId": "dataset1"},
+                "location": "US",
+                "description": "Test dataset 1",
+            },
+            {
+                "datasetReference": {"projectId": "project2", "datasetId": "specific"},
+                "location": "US",
+                # No description - will trigger dataset.get() call
+            },
+            {
+                "datasetReference": {"projectId": "project2", "datasetId": "other"},
+                "location": "US",
+            },
+            {
+                "datasetReference": {"projectId": "project3", "datasetId": "dataset1"},
+                "location": "US",
+            },
+        ]
+
+        with patch(
+            "bq_mcp.repositories.bigquery_client._paginate_bigquery_api"
+        ) as mock_paginate:
+            mock_paginate.return_value = datasets_list
+
+            # Mock the Dataset.get method directly to avoid internal async calls
+            with patch(
+                "gcloud.aio.bigquery.Dataset.get", new_callable=AsyncMock
+            ) as mock_get:
+                mock_get.return_value = {"description": "Fetched description"}
+
+                # Call the function
+                result = await bigquery_client.fetch_datasets(
+                    mock_client, "test_project"
+                )
+
+                # Should only return filtered datasets
+                assert len(result) == 2  # project1.dataset1 and project2.specific
+
+                # Verify project and dataset IDs
+                result_ids = [(r.project_id, r.dataset_id) for r in result]
+                expected_ids = [("project1", "dataset1"), ("project2", "specific")]
+                assert result_ids == expected_ids
+
+                # Verify dataset.get was called only for included datasets without description
+                # project2.specific has no description, so should call get()
+                mock_get.assert_called_once()
+
+    @patch("bq_mcp.repositories.config.get_settings")
+    @pytest.mark.asyncio
+    async def test_fetch_datasets_no_filters(self, mock_get_settings):
+        """Test that fetch_datasets processes all datasets when no filters are set"""
+        # Mock settings with no filters
+        mock_settings = MagicMock(spec=Settings)
+        mock_settings.dataset_filters = []
+        mock_get_settings.return_value = mock_settings
+
+        # Mock client
+        mock_client = MagicMock()
+        mock_client.session = MagicMock()
+        mock_client.session.session = MagicMock()
+        mock_client.token = MagicMock()
+
+        # Mock dataset list response - both have descriptions, so no .get() calls needed
+        datasets_list = [
+            {
+                "datasetReference": {"projectId": "project1", "datasetId": "dataset1"},
+                "location": "US",
+                "description": "Test dataset 1",
+            },
+            {
+                "datasetReference": {"projectId": "project2", "datasetId": "dataset2"},
+                "location": "US",
+                "description": "Test dataset 2",
+            },
+        ]
+
+        with patch(
+            "bq_mcp.repositories.bigquery_client._paginate_bigquery_api"
+        ) as mock_paginate:
+            mock_paginate.return_value = datasets_list
+
+            # Call the function - no dataset.get() should be called since all have descriptions
+            result = await bigquery_client.fetch_datasets(mock_client, "test_project")
+
+            # Should return all datasets
+            assert len(result) == 2
+
+            # Verify project and dataset IDs
+            result_ids = [(r.project_id, r.dataset_id) for r in result]
+            expected_ids = [("project1", "dataset1"), ("project2", "dataset2")]
+            assert result_ids == expected_ids
+
+    def test_fetch_datasets_filter_logic(self):
+        """Test that dataset filtering logic works correctly"""
+        # Test data simulating fetch_datasets scenario
+        datasets_data = [
+            {"datasetReference": {"projectId": "project1", "datasetId": "dataset1"}},
+            {"datasetReference": {"projectId": "project2", "datasetId": "specific"}},
+            {"datasetReference": {"projectId": "project2", "datasetId": "other"}},
+            {"datasetReference": {"projectId": "project3", "datasetId": "dataset1"}},
+        ]
+
+        filters = ["project1.*", "project2.specific"]
+
+        # Simulate the filtering logic from fetch_datasets
+        included_datasets = []
+        skipped_datasets = []
+
+        for dataset_data in datasets_data:
+            ds_ref = dataset_data.get("datasetReference", {})
+            project_id = ds_ref.get("projectId")
+            dataset_id = ds_ref.get("datasetId")
+
+            if should_include_dataset(project_id, dataset_id, filters):
+                included_datasets.append((project_id, dataset_id))
+            else:
+                skipped_datasets.append((project_id, dataset_id))
+
+        # Verify results
+        assert len(included_datasets) == 2
+        assert len(skipped_datasets) == 2
+
+        assert ("project1", "dataset1") in included_datasets
+        assert ("project2", "specific") in included_datasets
+        assert ("project2", "other") in skipped_datasets
+        assert ("project3", "dataset1") in skipped_datasets
+
+    def test_filter_performance_benefits(self):
+        """Test that demonstrates the performance benefits of early filtering"""
+        # This test verifies that our optimization logic works correctly
+        # by showing that filtered datasets are skipped before expensive operations
+
+        # Test data simulating a scenario with many datasets
+        all_datasets = [
+            ("project1", "dataset1"),
+            ("project1", "dataset2"),
+            ("project2", "dataset1"),
+            ("project2", "dataset2"),
+            ("project3", "dataset1"),
+            ("project3", "dataset2"),
+        ]
+
+        # Filter that only includes project1 datasets
+        filters = ["project1.*"]
+
+        # Count how many would be processed with and without optimization
+        included_count = 0
+        excluded_count = 0
+
+        for project_id, dataset_id in all_datasets:
+            if should_include_dataset(project_id, dataset_id, filters):
+                included_count += 1
+            else:
+                excluded_count += 1
+
+        # With optimization, only 2 datasets should be processed
+        assert included_count == 2
+        # 4 datasets should be skipped, avoiding expensive API calls
+        assert excluded_count == 4
+
+
+class TestDatasetFilterEdgeCases:
+    """Test edge cases for dataset filtering"""
+
+    def test_empty_project_or_dataset_ids(self):
+        """Test handling of empty project or dataset IDs"""
+        filters = ["project1.*"]
+
+        # Empty project ID - should not match
+        assert not should_include_dataset("", "dataset1", filters)
+
+        # Empty dataset ID - project1.* matches project1. (empty string)
+        # This is expected fnmatch behavior
+        assert should_include_dataset("project1", "", filters)
+
+        # Both empty - should not match
+        assert not should_include_dataset("", "", filters)
+
+        # Test with more specific filter to show empty dataset ID behavior
+        specific_filters = ["project1.specific_dataset"]
+        assert not should_include_dataset("project1", "", specific_filters)
+
+    def test_special_characters_in_filters(self):
+        """Test filters with special characters"""
+        filters = ["project-with-dashes.*", "project_with_underscores.dataset-name"]
+
+        # Should match project with dashes
+        assert should_include_dataset("project-with-dashes", "any_dataset", filters)
+
+        # Should match specific dataset with dashes
+        assert should_include_dataset(
+            "project_with_underscores", "dataset-name", filters
+        )
+
+        # Should not match similar but different names
+        assert not should_include_dataset("project_with_dashes", "any_dataset", filters)
+        assert not should_include_dataset(
+            "project_with_underscores", "dataset_name", filters
+        )
+
+
+# Run with: python -m pytest tests/test_bigquery_client.py -v


### PR DESCRIPTION
feat(mcp): クエリ実行プロジェクト設定とデータセットフィルタ最適化を追加

MCPサーバーにクエリ実行用のプロジェクトID設定機能を追加し、
データセットフィルタリングの最適化を実装。

- コマンドライン引数でGCPサービスアカウントキーとプロジェクトIDsを指定可能
- QUERY_EXECUTION_PROJECT_ID環境変数でクエリ実行用プロジェクトを設定
- データセットフィルタによる事前チェックでパフォーマンス向上
- pytest実行時のカバレッジレポートとmypy型チェックをドキュメントに追加
- BigQueryクライアントのデータセットフィルタ最適化テストを新規作成

Breaking Changes: なし
```