### PR TITLE
アプリケーションの初期設定時にプロジェクトIDの検証を追加し、設定が未構成の場合にエラーを発生させるようにしました。また、ロギングの初期化…

### DIFF
--- a/bq_mcp/adapters/mcp_server.py
+++ b/bq_mcp/adapters/mcp_server.py
@@ -33,7 +33,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[ApplicationContext]:
     )
     setting = config.init_setting()
     log.get_logger().info(
-        f"Initializing application context with settings: {setting.project_ids}"
+        "Initializing application context with settings: %s", setting.project_ids
     )
     if setting.project_ids is None or not setting.project_ids:
         raise ValueError("Project IDs must be configured in settings.")

--- a/bq_mcp/adapters/mcp_server.py
+++ b/bq_mcp/adapters/mcp_server.py
@@ -32,6 +32,11 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[ApplicationContext]:
         enable_file_log=os.getenv("ENABLE_FILE_LOGGING", "").lower() in ("1", "true"),
     )
     setting = config.init_setting()
+    log.get_logger().info(
+        f"Initializing application context with settings: {setting.project_ids}"
+    )
+    if setting.project_ids is None or not setting.project_ids:
+        raise ValueError("Project IDs must be configured in settings.")
     logger = log.get_logger()
 
     # Load existing cache without blocking startup

--- a/bq_mcp/repositories/config.py
+++ b/bq_mcp/repositories/config.py
@@ -66,7 +66,11 @@ def init_setting() -> Settings:
     """Initialize settings from environment variables"""
     # Load environment variables
     gcp_service_account_key_path = _load_env_variable("GCP_SERVICE_ACCOUNT_KEY_PATH")
-    project_ids = _load_env_variable("PROJECT_IDS", "").split(",")
+    project_ids = [
+        val
+        for val in _load_env_variable("PROJECT_IDS", "").split(",")
+        if val is not None and val.strip() != ""
+    ]
     dataset_filters = _parse_filter_list(_load_env_variable("DATASET_FILTERS", ""))
     cache_ttl_seconds = _load_env_variable("CACHE_TTL_SECONDS", 3600, int)
     cache_file_base_dir = os.path.abspath(

--- a/bq_mcp/repositories/log.py
+++ b/bq_mcp/repositories/log.py
@@ -33,7 +33,7 @@ def init_logger(
                 level=logging.INFO,
             )
             logger = logging.getLogger("bq_meta_api")
-            logger.info("Logger initialized.")
+            logger.info("Logger initialized. %s", "Logging to console")
         elif enable_file_log:
             DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
             log_dir = Path(Path(__file__).parent / "../../logs").resolve()
@@ -46,6 +46,12 @@ def init_logger(
             logger.propagate = False
             logger.addHandler(file_handler)
             logger.info("Logger initialized. Logging to file: %s", log_file)
+        else:
+            logger = logging.getLogger("bq_mcp")
+            logger.propagate = False
+            logger.disabled = True
+            logger.setLevel(logging.INFO)
+            logger.info("Logger initialized. No logging output configured.")
     return LogSetting(
         log_to_console=log_to_console, enable_file_logging=enable_file_log
     )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+
+from bq_mcp.adapters import mcp_server
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_error():
+    """Test the application lifespan context manager
+    assert raise error if project IDs are not configured.
+    """
+    app = mcp_server.mcp
+    os.environ.pop("PROJECT_IDS", None)  # Ensure no project IDs are set
+    with pytest.raises(ValueError, match="Project IDs must be configured in settings."):
+        async with mcp_server.app_lifespan(app):
+            pass
+    os.environ.pop("PROJECT_IDS", "")  # Ensure no project IDs are set
+    with pytest.raises(ValueError, match="Project IDs must be configured in settings."):
+        async with mcp_server.app_lifespan(app):
+            pass

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15,7 +15,7 @@ async def test_app_lifespan_error():
     with pytest.raises(ValueError, match="Project IDs must be configured in settings."):
         async with mcp_server.app_lifespan(app):
             pass
-    os.environ.pop("PROJECT_IDS", "")  # Ensure no project IDs are set
+    os.environ["PROJECT_IDS"] = ""  # Simulate an empty-string case for project IDs
     with pytest.raises(ValueError, match="Project IDs must be configured in settings."):
         async with mcp_server.app_lifespan(app):
             pass


### PR DESCRIPTION
…時に出力設定がない場合の処理を追加しました。テストケースを新規作成し、プロジェクトIDが未設定の場合の動作を確認しました。